### PR TITLE
hotfix(reports): add Redemption Cancellations row to Summary Report (UAT #10 cherry-pick)

### DIFF
--- a/src/pages/reports/SummaryReport.jsx
+++ b/src/pages/reports/SummaryReport.jsx
@@ -119,6 +119,15 @@ const metricExplanations = {
     filters:
       "Only admin redeem transactions within date range for this app type",
   },
+  redemptionCancellations: {
+    description:
+      "Points restored to customers when their redemptions were cancelled during the selected period. These are positive-point reversals that offset prior redemptions.",
+    formula:
+      "Adding up points from adjust transactions whose transaction ID ends with '_cancelled'",
+    dataSource: "Transaction records",
+    filters:
+      "Only completed cancellation adjustments within date range for this app type",
+  },
   netMovement: {
     description:
       "The net change in points during your selected period. This shows the overall movement of points after accounting for all earning, redeeming, expiring, adjusting, and admin reductions.",
@@ -527,6 +536,11 @@ const SummaryReport = () => {
         explanation: metricExplanations.adminReductionPoints,
       },
       {
+        label: "Redemption Cancellations",
+        type: "redemptionCancellations",
+        explanation: metricExplanations.redemptionCancellations,
+      },
+      {
         label: "Net Movement",
         type: "netMovement",
         explanation: metricExplanations.netMovement,
@@ -576,6 +590,9 @@ const SummaryReport = () => {
           rowData[appTypeName] = data?.totalExpiredPoints || 0;
         } else if (row.type === "adminReductionPoints") {
           rowData[appTypeName] = data?.adminReductionPoints || 0;
+        } else if (row.type === "redemptionCancellations") {
+          rowData[appTypeName] =
+            data?.redemptionCancellations?.totalPoints || 0;
         } else if (row.type === "netMovement") {
           // Calculate per app type net movement (closing - opening, since points have signs)
           const appTypeClosing = data?.closingBalance || 0;
@@ -617,6 +634,8 @@ const SummaryReport = () => {
         rowData["Total"] = totals.totalExpiredPoints || 0;
       } else if (row.type === "adminReductionPoints") {
         rowData["Total"] = totals.adminReductionPoints || 0;
+      } else if (row.type === "redemptionCancellations") {
+        rowData["Total"] = totals.redemptionCancellations?.totalPoints || 0;
       } else if (row.type === "netMovement") {
         rowData["Total"] = totals.netMovement || 0;
       }


### PR DESCRIPTION
## Summary

Hotfix cherry-pick of UAT PR #10 (already merged to UAT as `fcad556`) onto `prod`. Carries **only** the Redemption Cancellations row change — no unplanned UAT changes (build-system / VITE env tweaks) ride along.

Pairs with backend hotfix PR https://github.com/Xyvin-Technologies-Pvt-Ltd/backend_loyalty/pull/11.

## What it does

Adds a new row **"Redemption Cancellations"** between "Admin Manual Point Reduction" and "Net Movement" in the Summary Report detailed table. Consumes the new backend fields `reportData.<appType>.redemptionCancellations.totalPoints` and `totals.redemptionCancellations.totalPoints`, plus a metric tooltip explaining the data source and formula.

With this row visible, `Net Movement = Closing - Opening` equals the signed sum of all displayed rows, resolving the client-reported reconciliation issue for the April 2026 summary report.

## Diff

- 1 file changed, +19 / -0
- File: `src/pages/reports/SummaryReport.jsx`

## Test plan

- [ ] After backend hotfix PR merges to prod, open Summary Report → Custom Range 2026-04-01 to 2026-04-30
- [ ] Confirm "Redemption Cancellations" row appears between "Admin Manual Point Reduction" and "Net Movement"
- [ ] Confirm per-column: `Net Movement == Earned + Promo + Redeemed + Expired + Admin Reduction + Redemption Cancellations`
- [ ] Confirm per-column: `Closing Balance == Opening Balance + Net Movement`
- [ ] CSV export still works and includes the new row

Made with [Cursor](https://cursor.com)