### PR TITLE
fix: add sub-category note to Export Details panel in TransactionReport

### DIFF
--- a/src/pages/reports/TransactionReport.jsx
+++ b/src/pages/reports/TransactionReport.jsx
@@ -426,6 +426,11 @@ const TransactionReport = () => {
             <span className="w-2 h-2 bg-green-600 rounded-full"></span>
             <span className="text-gray-700">Transaction Type</span>
           </div>
+          <div className="flex items-start gap-2 ml-4">
+            <span className="text-xs text-gray-500 mt-0.5">
+              Adjust rows are sub-categorised as <code>redemption_cancellation</code>, <code>promotion</code>, or <code>admin_reduction</code> based on the transaction reference.
+            </span>
+          </div>
           <div className="flex items-center gap-2">
             <span className="w-2 h-2 bg-green-600 rounded-full"></span>
             <span className="text-gray-700">Points</span>


### PR DESCRIPTION
## Summary

- Added a one-line explanatory note in the **Export Details** panel of the Transaction Report page explaining that `adjust` rows in the CSV export now use sub-category labels (`redemption_cancellation`, `promotion`, `admin_reduction`) for the `transaction_type` column.
- This is a copy-only change; no logic is altered.

## Files changed

- `src/pages/reports/TransactionReport.jsx`

## Test plan

- [ ] Open Transaction Report page and expand Export Details
- [ ] Confirm the note about sub-category labels is visible under the Transaction Type bullet

Made with [Cursor](https://cursor.com)