### PR TITLE
hotfix: add sub-category note to Export Details panel in TransactionReport

### DIFF
--- a/src/pages/reports/TransactionReport.jsx
+++ b/src/pages/reports/TransactionReport.jsx
@@ -426,6 +426,11 @@ const TransactionReport = () => {
             <span className="w-2 h-2 bg-green-600 rounded-full"></span>
             <span className="text-gray-700">Transaction Type</span>
           </div>
+          <div className="flex items-start gap-2 ml-4">
+            <span className="text-xs text-gray-500 mt-0.5">
+              Adjust rows are sub-categorised as <code>redemption_cancellation</code>, <code>promotion</code>, or <code>admin_reduction</code> based on the transaction reference.
+            </span>
+          </div>
           <div className="flex items-center gap-2">
             <span className="w-2 h-2 bg-green-600 rounded-full"></span>
             <span className="text-gray-700">Points</span>


### PR DESCRIPTION
## Summary (cherry-pick of UAT PR #12)

Copy-only change: one-line explanatory note added in the Export Details panel of the Transaction Report page explaining that `adjust` rows in the CSV use sub-category labels (`redemption_cancellation`, `promotion`, `admin_reduction`) for the `transaction_type` column.

## Scope

Cherry-pick only — no other UAT changes included.

## Test plan

- [ ] Merge UAT PR #12 first
- [ ] Open Transaction Report page → Export Details → confirm the note is visible under Transaction Type

Made with [Cursor](https://cursor.com)